### PR TITLE
Fixes for basic 5.0 printing support

### DIFF
--- a/QidiConnectionManager.py
+++ b/QidiConnectionManager.py
@@ -1,5 +1,5 @@
-from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtNetwork import QUdpSocket, QHostAddress
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtNetwork import QUdpSocket, QHostAddress
 
 from typing import Union, Optional, List, cast, TYPE_CHECKING
 from time import time, sleep

--- a/QidiMachineConfig.py
+++ b/QidiMachineConfig.py
@@ -8,17 +8,17 @@ from cura.MachineAction import MachineAction
 from UM.PluginRegistry import PluginRegistry
 from cura.CuraApplication import CuraApplication
 
-from PyQt5.QtCore import pyqtSignal, pyqtProperty, pyqtSlot, QUrl, QObject
-from PyQt5.QtQml import QQmlComponent, QQmlContext
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtNetwork import QNetworkRequest, QNetworkAccessManager
+from PyQt6.QtCore import pyqtSignal, pyqtProperty, pyqtSlot, QUrl, QObject
+from PyQt6.QtQml import QQmlComponent, QQmlContext
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtNetwork import QNetworkRequest, QNetworkAccessManager
 
 import os.path
 import json
 import base64
 import time
 
-from PyQt5.QtCore import QTimer
+from PyQt6.QtCore import QTimer
 
 catalog = i18nCatalog("cura")
 

--- a/QidiPrintOutputDevice.py
+++ b/QidiPrintOutputDevice.py
@@ -5,9 +5,9 @@ from time import time, sleep
 import subprocess, re, threading, platform, struct, traceback, sys, base64, json, urllib
 from typing import cast, Any, Callable, Dict, List, Optional
 
-from PyQt5.QtCore import QFile, QUrl, QObject, QCoreApplication, QByteArray, QTimer, pyqtProperty, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtQml import QQmlComponent, QQmlContext
+from PyQt6.QtCore import QFile, QUrl, QObject, QCoreApplication, QByteArray, QTimer, pyqtProperty, pyqtSignal, pyqtSlot
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtQml import QQmlComponent, QQmlContext
 from timeit import default_timer as Timer
 
 from cura.CuraApplication import CuraApplication

--- a/QidiPrintPlugin.py
+++ b/QidiPrintPlugin.py
@@ -1,6 +1,6 @@
 import re, os.path, json, threading, time
-from PyQt5.QtCore import QObject, QUrl, pyqtProperty, pyqtSignal, pyqtSlot
-from PyQt5.QtQml import QQmlComponent, QQmlContext
+from PyQt6.QtCore import QObject, QUrl, pyqtProperty, pyqtSignal, pyqtSlot
+from PyQt6.QtQml import QQmlComponent, QQmlContext
 
 from UM.Message import Message
 from UM.Logger import Logger
@@ -48,7 +48,6 @@ class QidiPrintPlugin(QObject, OutputDevicePlugin):
             "label": "Chamber Loop Fans",
             "description": "Enables Chamber Loop fans while printing",
             "type": "bool",
-            "resolve": "any(extruderValues('cooling_chamber'))",
             "default_value": False,
             "settable_per_mesh": False,
             "settable_per_extruder": False,
@@ -58,7 +57,6 @@ class QidiPrintPlugin(QObject, OutputDevicePlugin):
             "label": "Start Chamber Loop on Layer",
             "description": "Start Chamber Loop on Layer Nr",
             "type": "int",
-            "resolve": "min(extruderValues('cooling_chamber_at_layer'))",
             "unit": "layer",
             "default_value": 1,
             "minimum_value": 1,

--- a/plugin.json
+++ b/plugin.json
@@ -4,6 +4,6 @@
     "description": "Enables remote printing and monitoring of Qidi 3D printers over network",
     "version": "1.3.0",
     "api": 5,
-    "supported_sdk_versions": ["7.2.0", "7.3.0"],
+    "supported_sdk_versions": ["7.2.0", "7.3.0", "8.0.0"],
     "i18n-catalog": "cura"
 }

--- a/qml/UploadFilename.qml
+++ b/qml/UploadFilename.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.1
-import QtQuick.Controls 1.1
-import QtQuick.Dialogs 1.2
-import QtQuick.Window 2.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
+import QtQuick.Window
 
 import UM 1.1 as UM
 
@@ -66,7 +66,6 @@ UM.Dialog
             text: catalog.i18nc("@action:button", "OK");
             onClicked: base.accept();
             enabled: base.validName;
-            isDefault: true;
         }
     ]
 }


### PR DESCRIPTION
Hi - this doesn't fix everything (and would break 4.x so that would need considered) but it does allow at least an existing, configured install of QidiPrint to work on Cura 5.0. I was able to push a print to the printer via network, but the monitoring doesn't work.